### PR TITLE
Add source manager with Streamlit sidebar editor

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -11,6 +11,7 @@ handler = InputHandler()
 language = handler.select_language()
 engine_name = handler.select_engine()
 profile = handler.select_profile(engine_name)
+handler.sources_widget(language)
 
 query_label = 'Запрос' if language == 'Русский' else 'Query'
 query = st.text_input(query_label)

--- a/app/source_manager.py
+++ b/app/source_manager.py
@@ -1,0 +1,21 @@
+import json
+import os
+from typing import List, Dict
+
+SOURCES_PATH = os.path.join(os.path.dirname(__file__), '..', 'profiles', 'sources.json')
+
+class SourceManager:
+    def __init__(self, path: str = SOURCES_PATH):
+        self.path = path
+        os.makedirs(os.path.dirname(self.path), exist_ok=True)
+        if not os.path.exists(self.path):
+            with open(self.path, 'w', encoding='utf-8') as f:
+                json.dump([], f)
+
+    def load_sources(self) -> List[Dict[str, str]]:
+        with open(self.path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+
+    def save_sources(self, sources: List[Dict[str, str]]):
+        with open(self.path, 'w', encoding='utf-8') as f:
+            json.dump(sources, f, ensure_ascii=False, indent=2)


### PR DESCRIPTION
## Summary
- manage sources in new `source_manager.py`
- allow editing/uploading sources via `InputHandler.sources_widget`
- show source editor in sidebar from `app/app.py`

## Testing
- `python -m py_compile app/app.py app/input_handler.py app/source_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_6843b458fc90832793289a1f18348ffc